### PR TITLE
Some quick fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ use get_port;
 
 fn main() {
     let an_available_port = get_port::get_port().unwrap(); // Returns the first available port in default range
-    let an_available_port_in_range = get_port::get_port_in_range(get_port::Range { min: 5000, max: 6000 }).unwrap(); // Returns the first available port in speciefied range
+    let an_available_port_in_range = get_port::get_port_in_range(get_port::PortRange { min: 5000, max: 6000 }).unwrap(); // Returns the first available port in speciefied range
 
     // ...
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ use std::net::{ TcpListener, Ipv4Addr };
 
 #[derive(Debug)]
 pub struct PortRange {
-    min: u16,
-    max: u16
+    pub min: u16,
+    pub max: u16
 }
 
 impl Default for PortRange {


### PR DESCRIPTION
* Made `PortRange` members public to make them settable outside of the module.
* Corrected the example in `README.md`