### PR TITLE
Fix GitHub URL in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Carlos Menezes <carlos-menezes212@hotmail.com>"]
 description = "Get an available port"
 license = "MIT"
 edition = "2018"
-repository = "https://github.com/carlos-menezes/get-port"
+repository = "https://github.com/carlos-menezes/get_port"
 keywords = ["port", "network"]
 readme = "README.md"
 


### PR DESCRIPTION
The old URL pointed to a 404. Fixed it by replacing a "-" with an "_".